### PR TITLE
[WIP] Return all field descriptions

### DIFF
--- a/dist/easy-fit.js
+++ b/dist/easy-fit.js
@@ -86,6 +86,7 @@ var EasyFit = function () {
       var laps = [];
       var records = [];
       var events = [];
+      var field_descriptions = [];
 
       var tempLaps = [];
       var tempRecords = [];
@@ -136,6 +137,9 @@ var EasyFit = function () {
               tempRecords.push(message);
             }
             break;
+          case 'field_description':
+            field_descriptions.push(message);
+            break
           default:
             if (messageType !== '') {
               fitObj[messageType] = message;
@@ -153,6 +157,7 @@ var EasyFit = function () {
         fitObj.laps = laps;
         fitObj.records = records;
         fitObj.events = events;
+        fitObj.field_descriptions = field_descriptions;
       }
 
       callback(null, fitObj);

--- a/src/easy-fit.js
+++ b/src/easy-fit.js
@@ -70,6 +70,7 @@ export default class EasyFit {
     const laps = [];
     const records = [];
     const events = [];
+    var field_descriptions = [];
 
     let tempLaps = [];
     let tempRecords = [];
@@ -118,6 +119,9 @@ export default class EasyFit {
             tempRecords.push(message);
           }
           break;
+        case 'field_description':
+            field_descriptions.push(message);
+            break
         default:
           if (messageType !== '') {
             fitObj[messageType] = message;
@@ -135,6 +139,7 @@ export default class EasyFit {
       fitObj.laps = laps;
       fitObj.records = records;
       fitObj.events = events;
+      fitObj.field_descriptions = field_descriptions;
     }
 
     callback(null, fitObj);


### PR DESCRIPTION
Previously, when parsing the .FIT file, everything except `lap`, `session`, `event`, and `record` where ignored, in that, for example, only the last value of the developer `field_description` was set as a property of the exported file. This made it impossible to see all of the developer fields that existed in a .FIT file.

With the changes in this PR, all of the developer `field_description` are included as an array in the exported file object. This makes it easy to take a look to see which developer fields are present.