### PR TITLE
Name developer field with data index

### DIFF
--- a/dist/binary.js
+++ b/dist/binary.js
@@ -359,6 +359,8 @@ function readRecord(blob, messageTypes, developerFields, startIndex, options, st
     }
 
     if (message.name === 'field_description') {
+        // Developer data fields may not be unique. Append with data index.
+        fields.field_name = fields.field_name + '_' + fields.developer_data_index;
         developerFields[fields.developer_data_index] = developerFields[fields.developer_data_index] || [];
         developerFields[fields.developer_data_index][fields.field_definition_number] = fields;
     }

--- a/src/binary.js
+++ b/src/binary.js
@@ -337,6 +337,8 @@ export function readRecord(blob, messageTypes, developerFields, startIndex, opti
     }
 
     if (message.name === 'field_description') {
+        // Developer data fields may not be unique. Append with data index.
+        fields.field_name = `${fields.field_name}_${fields.developer_data_index}`;
         developerFields[fields.developer_data_index] = developerFields[fields.developer_data_index] || [];
         developerFields[fields.developer_data_index][fields.field_definition_number] = fields;
     }


### PR DESCRIPTION
This (WIP) PR appends the name of developer data fields with their corresponding `developer_data_index`. The reason is that more than one developer data field may be used, each that has fields with the same name. In the current implementation, only one of these fields will be populated in each record.

This PR (inelegantly) differentiates between these multiple developer data fields by appending the `developer_data_index` to the end of the name.